### PR TITLE
Fix hanging node processes on interrupt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches-ignore:
-      - master
   pull_request:
     branches:
       - master

--- a/lib/withinTime.js
+++ b/lib/withinTime.js
@@ -36,7 +36,7 @@ const runningChildren = new Set();
 
 process.on('SIGINT', () => {
   sendInterruptedMessage(runningChildren.size);
-  runningChildren.forEach(childProcess => childProcess.kill('SIGKILL'));
+  runningChildren.forEach(childProcess => childProcess.kill('SIGINT'));
 });
 
 module.exports = absoluteFilePath => {
@@ -56,10 +56,11 @@ module.exports = absoluteFilePath => {
     }
   }, timeout);
 
-  childProcess.on('exit', () => {
+  childProcess.on('exit', (code, signal) => {
     runningChildren.delete(childProcess);
     shouldClose = false;
-    if (!killed) {
+    // Null signal indicates
+    if (!killed && signal !== 'SIGINT') {
       sendSuccessMessage(fileName);
     }
     clearTimeout(closeProcessTimeout);

--- a/lib/withinTime.js
+++ b/lib/withinTime.js
@@ -18,8 +18,15 @@ const sendSuccessMessage = fileName => {
 };
 
 const sendInterruptedMessage = count => {
+  let childProcessCountBlurb;
+
+  if (count > 1) {
+    childProcessCountBlurb = `${count} child processes`;
+  } else {
+    childProcessCountBlurb = `${count} child process`;
+  }
   const interruptedMessage = chalk.red(
-    `Within Time interrupted, closing ${count} child processes`,
+    `Within Time interrupted, closing ${childProcessCountBlurb}`,
   );
   console.log('\n');
   console.log(interruptedMessage);
@@ -28,14 +35,14 @@ const sendInterruptedMessage = count => {
 const runningChildren = new Set();
 
 process.on('SIGINT', () => {
-  sendInterruptedMessage(runningChildren.entries.length);
+  sendInterruptedMessage(runningChildren.size);
   runningChildren.forEach(childProcess => childProcess.kill('SIGKILL'));
 });
 
 module.exports = absoluteFilePath => {
   let shouldClose = true;
   let killed = false;
-  childProcess = child_process.fork(absoluteFilePath);
+  const childProcess = child_process.fork(absoluteFilePath);
   runningChildren.add(childProcess);
 
   const fileName = absoluteFilePath.split('/').pop();

--- a/lib/withinTime.js
+++ b/lib/withinTime.js
@@ -17,10 +17,26 @@ const sendSuccessMessage = fileName => {
   console.log(successMessage);
 };
 
+const sendInterruptedMessage = count => {
+  const interruptedMessage = chalk.red(
+    `Within Time interrupted, closing ${count} child processes`,
+  );
+  console.log('\n');
+  console.log(interruptedMessage);
+};
+
+const runningChildren = new Set();
+
+process.on('SIGINT', () => {
+  sendInterruptedMessage(runningChildren.entries.length);
+  runningChildren.forEach(childProcess => childProcess.kill('SIGKILL'));
+});
+
 module.exports = absoluteFilePath => {
   let shouldClose = true;
   let killed = false;
   childProcess = child_process.fork(absoluteFilePath);
+  runningChildren.add(childProcess);
 
   const fileName = absoluteFilePath.split('/').pop();
   const timeout = process.env.NODE_ENV === 'test' ? 200 : 1000;
@@ -34,6 +50,7 @@ module.exports = absoluteFilePath => {
   }, timeout);
 
   childProcess.on('exit', () => {
+    runningChildren.delete(childProcess);
     shouldClose = false;
     if (!killed) {
       sendSuccessMessage(fileName);


### PR DESCRIPTION
# Fix hanging node processes on interrupt

## Description
### PR Type

- [X] Bug fix
- [ ] Feature
- [ ] Other

### Summary
SIGINT calls (ctrl + c) to the process would leave child processes running

Fixes Issue #4 

### Fix
Added a Set to push childProcesses into.
Added a `SIGINT` listener to the main process to kill child processes before exiting.
Added a new log message to include that information

### Other Details

![image](https://user-images.githubusercontent.com/3011292/76372097-ba09ff80-6312-11ea-967d-42d042e5196e.png)
