### PR TITLE
Do Not Run Non-JS Files

### DIFF
--- a/lib/fsHelper.js
+++ b/lib/fsHelper.js
@@ -22,7 +22,9 @@ class FSHelper {
 
     const readDirAsync = promisify(fs.readdir);
     const dirContents = await readDirAsync(this.path, { withFileTypes: true });
-    const dirFiles = dirContents.filter(dirEnt => dirEnt.isFile());
+    const dirFiles = dirContents.filter(
+      dirEnt => dirEnt.isFile() && dirEnt.name.endsWith('.js'),
+    );
     const filePaths = dirFiles.map(dirEnt => `${this.path}/${dirEnt.name}`);
     return filePaths;
   }

--- a/lib/fsHelper.js
+++ b/lib/fsHelper.js
@@ -12,7 +12,7 @@ class FSHelper {
   }
 
   get isFile() {
-    return this.stats.isFile();
+    return this.stats.isFile() && this.path.endsWith('.js');
   }
 
   async getFilePaths() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "within-time",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Run Node.js files with a set timeout",
   "main": "index.js",
   "repository": "https://github.com/kwak123/within-time",

--- a/test/fsHelper.spec.js
+++ b/test/fsHelper.spec.js
@@ -29,6 +29,7 @@ describe('FSHelper', () => {
           path.resolve('./test/fsScenarios/fileTwo.js'),
         ];
         const receivedFilePaths = await subject.getFilePaths();
+        expect(receivedFilePaths).toHaveLength(expectedFilePaths.length);
         expectedFilePaths.forEach(filePath =>
           expect(receivedFilePaths).toContain(filePath),
         );

--- a/test/fsHelper.spec.js
+++ b/test/fsHelper.spec.js
@@ -38,11 +38,11 @@ describe('FSHelper', () => {
   });
 
   describe('with file path', () => {
-    const filePath = path.resolve('./test/fsScenarios/fileOne.js');
+    const jsFilePath = path.resolve('./test/fsScenarios/fileOne.js');
     let subject;
 
     beforeEach(() => {
-      subject = new FSHelper(filePath);
+      subject = new FSHelper(jsFilePath);
     });
 
     describe('isDirectory', () => {
@@ -52,8 +52,16 @@ describe('FSHelper', () => {
     });
 
     describe('isFile', () => {
-      it('should return true', () => {
+      it('should return true if given JS file path', () => {
+        const validJSFilePath = jsFilePath;
+        subject = new FSHelper(validJSFilePath);
         expect(subject.isFile).toBe(true);
+      });
+
+      it('should return false if given non-JS file path', () => {
+        const nonJSFilePath = path.resolve('./test/fsScenarios/nonJsFile');
+        subject = new FSHelper(nonJSFilePath);
+        expect(subject.isFile).toBe(false);
       });
     });
 


### PR DESCRIPTION
# Exclude Non-JS Files
## Description
### PR Type
- [X] Bug fix
- [ ] Feature
- [ ] Other

### Summary
#8 Non-JS files are running when called via directory or direct path

### Fix
Previously, there was a js file ending check. I added this back in to only ally 

### Other Details
Error log is real ugly, needs to be improved, Projects card updated.
